### PR TITLE
Read data form spreadsheet

### DIFF
--- a/tests/common/test_spreadsheet.py
+++ b/tests/common/test_spreadsheet.py
@@ -35,3 +35,18 @@ def test_read() -> None:
 
     _mock_spreadsheet.worksheet.assert_called_once_with(mock_title)
     mock_worksheet.get.assert_called_once_with(mock_range)
+
+
+def test_write() -> None:
+    mock_title = "Hesitation"
+    mock_range = "Defeat"
+    mock_data = [["A"], ["B"], ["C"]]
+
+    mock_worksheet = mock.MagicMock()
+    _mock_spreadsheet = mock.MagicMock()
+    _mock_spreadsheet.worksheet.return_value = mock_worksheet
+
+    spreadsheet.SpreadSheet(_mock_spreadsheet).write(mock_title, mock_range, mock_data)
+
+    _mock_spreadsheet.worksheet.assert_called_once_with(mock_title)
+    mock_worksheet.update.assert_called_once_with(mock_data, mock_range)

--- a/tests/common/test_spreadsheet.py
+++ b/tests/common/test_spreadsheet.py
@@ -1,0 +1,37 @@
+from unittest import mock
+
+from vigilant.common import spreadsheet
+
+
+@mock.patch("vigilant.common.spreadsheet.google.auth")
+@mock.patch("vigilant.common.spreadsheet.gspread")
+def test_load(mock_gspread: mock.MagicMock, mock_google_auth: mock.MagicMock) -> None:
+    mock_google_auth.default.return_value = ("A", "B")
+    spreadsheet_key = "ABC123"
+
+    spreadsheet.SpreadSheet.load(spreadsheet_key)
+
+    mock_google_auth.default.assert_called_once()
+    mock_gspread.authorize.assert_called_once_with("A")
+    mock_gspread.authorize().open_by_key.assert_called_once_with(spreadsheet_key)
+
+
+def test_read() -> None:
+    mock_title = "Hesitation"
+    mock_range = "Defeat"
+    mock_data = [["A"], ["B"], ["C"]]
+
+    mock_worksheet = mock.MagicMock()
+    mock_worksheet.get.return_value = mock_data
+
+    _mock_spreadsheet = mock.MagicMock()
+    _mock_spreadsheet.worksheet.return_value = mock_worksheet
+
+    data: list[list[str]] = spreadsheet.SpreadSheet(_mock_spreadsheet).read(
+        mock_title, mock_range
+    )
+
+    assert data == mock_data
+
+    _mock_spreadsheet.worksheet.assert_called_once_with(mock_title)
+    mock_worksheet.get.assert_called_once_with(mock_range)

--- a/vigilant/common/spreadsheet.py
+++ b/vigilant/common/spreadsheet.py
@@ -42,3 +42,15 @@ class SpreadSheet:
         worksheet: gspread.Worksheet = self._spreadsheet.worksheet(worksheet_title)
 
         return worksheet.get(range)
+
+    def write(self, worksheet_title, range: str, data: list[list[str]]) -> None:
+        """Write data into a range of a worksheet
+
+        Args:
+            worksheet_title (str): Title of the worksheet
+            range (str): Location from where to read the data
+            data (list[list[str]]): Data to write in cells
+        """
+        worksheet: gspread.Worksheet = self._spreadsheet.worksheet(worksheet_title)
+
+        worksheet.update(data, range)

--- a/vigilant/common/spreadsheet.py
+++ b/vigilant/common/spreadsheet.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import google.auth
+import gspread
+
+
+class SpreadSheet:
+    _spreadsheet: gspread.Spreadsheet
+
+    def __init__(self, spreadsheet=gspread.Spreadsheet):
+        self._spreadsheet = spreadsheet
+
+    @staticmethod
+    def load(key: str) -> SpreadSheet:
+        """Login to GCP and returns an authorized spreadsheet instance
+
+        Args:
+            key (str): Unique key of the spreadsheet
+
+        Returns:
+            SpreadSheet: Authorized spreadsheet
+        """
+        scopes: list[str] = [
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://www.googleapis.com/auth/drive",
+        ]
+        credentials, _ = google.auth.default(scopes=scopes)
+        gc: gspread.Client = gspread.authorize(credentials)
+
+        return SpreadSheet(gc.open_by_key(key))
+
+    def read(self, worksheet_title: str, range: str) -> list[list[str]]:
+        """Reads from a range in a worksheet
+
+        Args:
+            worksheet_title (str): Title of the worksheet
+            range (str): Location from where to read the data
+
+        Returns:
+            list[list[str]]: Data from the range
+        """
+        worksheet: gspread.Worksheet = self._spreadsheet.worksheet(worksheet_title)
+
+        return worksheet.get(range)

--- a/vigilant/common/values.py
+++ b/vigilant/common/values.py
@@ -61,6 +61,10 @@ class IOResources:
 class BalanceSpreadsheet:
     KEY: Final[str] = "1IKyPmWeaZ_5IRa4I4EOgVwu5oGZ9RSQqQxjRu9P4qY4"
 
+    DATA_WORKSHEET_NAME: Final[str] = "Data"
+
+    PAYMENT_DESC_RANGE: Final[str] = "B3:B12"
+
     EXPENSES_WORKSHEET_NAME: Final[str] = "Gastos"
 
     AMOUNT_CELL: Final[str] = "I2"


### PR DESCRIPTION
Decouple spreadsheet object initialization to simplify reading and writing data in various sections of the application.

Now the list of card payment descriptions used to filter rows are being read from the spreadsheet to address this issue [Move Description row filter values to an external data source](https://github.com/gcornejov/vigilant/issues/11).