### PR TITLE
Handle empty transactions in Banco Chile scraper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: snok/install-poetry@v1
         with:
           virtualenvs-path: .venv
-      
+
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4
@@ -29,12 +29,14 @@ jobs:
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
-      
+
       - name: Install project
         run: poetry install --no-interaction
-      
+
       - name: Run tests
         run: poetry run pytest --cov-report=xml
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
     <a href="https://www.python.org/doc/versions/" target="_blank">
         <img
             alt="Python Version from PEP 621 TOML"
-            src="https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fgcornejov%2Fvigilant%2Fmain%2Fpyproject.toml&logo=Python&labelColor=ffde57&color=4584b6"
+            src="https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Frobbit-o%2Fvigilant%2Fmain%2Fpyproject.toml&logo=Python&labelColor=ffde57&color=4584b6"
             alt="Python version"
         />
     </a>
-    <a href="https://codecov.io/gh/gcornejov/vigilant">
+    <a href="https://codecov.io/gh/robbit-o/vigilant">
         <img
-            src="https://codecov.io/gh/gcornejov/vigilant/graph/badge.svg?token=VIWE3BIDB3"
+            src="https://codecov.io/gh/robbit-o/vigilant/graph/badge.svg?token=VIWE3BIDB3"
             alt="Code coverage"
         />
     </a>

--- a/tests/core/collector/scraper/test_banco_chile_scrapper.py
+++ b/tests/core/collector/scraper/test_banco_chile_scrapper.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 import pandas as pd
+from playwright.sync_api import TimeoutError
 
 from vigilant.core.collector.scraper import BancoChileScraper
 from vigilant.core.collector.scraper.banco_chile.values import IOResources
@@ -13,6 +14,13 @@ from vigilant.core.collector.scraper.banco_chile.values import IOResources
 @pytest.fixture
 def mock_bank_chile_data() -> dict:
     return json.loads(Path("tests/resources/bank_chile.json").read_text())
+
+
+@pytest.fixture
+def mock_bank_chile_no_transactions_data() -> dict:
+    return json.loads(
+        Path("tests/resources/bank_chile_no_transactions.json").read_text()
+    )
 
 
 @mock.patch("vigilant.core.collector.scraper.BancoChileScraper._login")
@@ -79,16 +87,39 @@ def test_get_credit_transactions(tmp_path: Path, mock_page: mock.MagicMock) -> N
     )
 
 
+def test_get_credit_transactions_empty(mock_page: mock.MagicMock) -> None:
+    mock_click = mock.MagicMock()
+    mock_click.side_effect = TimeoutError("")
+    mock_locator = mock.MagicMock()
+
+    mock_locator.click = mock_click
+    mock_page.locator.return_value = mock_locator
+
+    scraper = BancoChileScraper(mock_page)
+
+    scraper._get_credit_transactions()
+
+    mock_page.goto.assert_called_once()
+    mock_page.locator().click.assert_called_once()
+    mock_page.locator().wait_for.assert_called_once()
+
+
 @mock.patch("vigilant.core.collector.scraper.banco_chile.scraper.SpreadSheet")
 @mock.patch("vigilant.core.collector.scraper.banco_chile.scraper.pd.read_excel")
 def test_save(
     mock_pd_read_excel: mock.MagicMock,
     MockSpreadSheet: mock.MagicMock,
     tmp_path: Path,
+    tmp_path_factory: pytest.TempPathFactory,
     monkeypatch: pytest.MonkeyPatch,
     mock_page: mock.MagicMock,
     mock_bank_chile_data: dict,
 ) -> None:
+    mock_data_path: Path = tmp_path_factory.mktemp("data")
+    (mock_data_path / IOResources.TRANSACTIONS_FILENAME).write_text(
+        "Hesitation is defeat!"
+    )
+
     mock_cols_keys: tuple[str] = ("date", "description", "location", "amount")
     mock_cols_index: tuple[str] = (1, 4, 6, 10)
 
@@ -121,7 +152,7 @@ def test_save(
     )
 
     scraper = BancoChileScraper(mock_page)
-    scraper.data_path = Path("/")
+    scraper.data_path = mock_data_path
     scraper.amount = 123456
 
     scraper._save()
@@ -129,10 +160,36 @@ def test_save(
     bank_output: dict = json.loads(Path(tmp_path / "bank_data.json").read_text())
 
     mock_pd_read_excel.assert_called_once_with(
-        Path("/", IOResources.TRANSACTIONS_FILENAME),
+        mock_data_path / IOResources.TRANSACTIONS_FILENAME,
         sheet_name=0,
         header=17,
         names=mock_cols_keys,
         usecols=mock_cols_index,
     )
     assert bank_output == mock_bank_chile_data
+
+
+def test_save_no_transactions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_page: mock.MagicMock,
+    mock_bank_chile_no_transactions_data: dict,
+) -> None:
+    monkeypatch.setattr(
+        "vigilant.common.values.IOResources.OUTPUT_PATH",
+        tmp_path,
+    )
+    monkeypatch.setattr(
+        "vigilant.core.collector.scraper.banco_chile.values.IOResources.OUTPUT_FILENAME",
+        "bank_data.json",
+    )
+
+    scraper = BancoChileScraper(mock_page)
+    scraper.data_path = Path("/")
+    scraper.amount = 123456
+
+    scraper._save()
+
+    bank_output: dict = json.loads(Path(tmp_path / "bank_data.json").read_text())
+
+    assert bank_output == mock_bank_chile_no_transactions_data

--- a/tests/core/test_update_spreadsheet.py
+++ b/tests/core/test_update_spreadsheet.py
@@ -59,6 +59,13 @@ def test_update_balance_spreadsheet(MockSpreadSheet: mock.MagicMock) -> None:
     mock_spreadsheet = mock.MagicMock()
     MockSpreadSheet.load.return_value = mock_spreadsheet
 
-    update_spreadsheet.update_balance_spreadsheet(mock_spreadsheet, 0, [[]])
+    initial_expenses = [["store", 100], ["restaurant", 50]]
+    update_spreadsheet.update_balance_spreadsheet(
+        mock_spreadsheet, 1000, initial_expenses
+    )
 
-    mock_spreadsheet.write.assert_called()
+    calls = mock_spreadsheet.write.call_args_list
+    expenses_call = calls[1]
+    written_expenses = expenses_call[0][2]
+
+    assert len(written_expenses) == update_spreadsheet.TRANSACTIONS_COUNT

--- a/tests/resources/bank_chile_no_transactions.json
+++ b/tests/resources/bank_chile_no_transactions.json
@@ -1,0 +1,5 @@
+{
+    "identifier": "Chile",
+    "amount": 123456,
+    "transactions": []
+}

--- a/vigilant/core/collector/scraper/banco_chile/scraper.py
+++ b/vigilant/core/collector/scraper/banco_chile/scraper.py
@@ -65,7 +65,12 @@ class BancoChileScraper(Scraper):
         self.logger.info("Getting transactions ...")
 
         self.page.goto(secrets.CREDIT_TRANSACTIONS_URL)
-        self.page.locator(Locators.DOWNLOAD_GROUP_BTN_XPATH).click()
+
+        try:
+            self.page.locator(Locators.DOWNLOAD_GROUP_BTN_XPATH).click()
+        except TimeoutError:
+            self.page.locator(Locators.NO_TRANSACTIONS_CLASS).wait_for(state="visible")
+            return
 
         with self.page.expect_download() as download_info:
             self.page.locator(Locators.DOWNLOAD_BTN_XPATH).click()
@@ -76,44 +81,49 @@ class BancoChileScraper(Scraper):
         """Structure and saves collected data in a json file"""
         self.logger.info("Saving data ...")
 
-        EXPENSES_COLUMNS_INDEX: tuple[str] = (1, 4, 6, 10)
-        EXPENSES_COLUMNS_KEYS: tuple[str] = (
-            "date",
-            "description",
-            "location",
-            "amount",
-        )
-
-        expenses: pd.DataFrame = pd.read_excel(
-            self.data_path / IOResources.TRANSACTIONS_FILENAME,
-            sheet_name=0,
-            header=17,
-            names=EXPENSES_COLUMNS_KEYS,
-            usecols=EXPENSES_COLUMNS_INDEX,
-        )
-
-        spreadsheet = SpreadSheet.load(balance_spreadsheet.KEY)
-        payment_descriptions: list[str] = [
-            desc.pop()
-            for desc in spreadsheet.read(
-                balance_spreadsheet.DATA_WORKSHEET_NAME,
-                balance_spreadsheet.PAYMENT_DESC_RANGE,
+        transactions_file = self.data_path / IOResources.TRANSACTIONS_FILENAME
+        collected_transactions: list[Transaction] = []
+        if transactions_file.exists():
+            EXPENSES_COLUMNS_INDEX: tuple[str] = (1, 4, 6, 10)
+            EXPENSES_COLUMNS_KEYS: tuple[str] = (
+                "date",
+                "description",
+                "location",
+                "amount",
             )
-        ]
 
-        expenses = expenses[(~expenses.description.isin(payment_descriptions))].fillna(
-            ""
-        )
+            expenses: pd.DataFrame = pd.read_excel(
+                transactions_file,
+                sheet_name=0,
+                header=17,
+                names=EXPENSES_COLUMNS_KEYS,
+                usecols=EXPENSES_COLUMNS_INDEX,
+            )
 
-        account_data = AccountData(
-            identifier=self.identifier,
-            amount=self.amount,
-            transactions=[
+            spreadsheet = SpreadSheet.load(balance_spreadsheet.KEY)
+            payment_descriptions: list[str] = [
+                desc.pop()
+                for desc in spreadsheet.read(
+                    balance_spreadsheet.DATA_WORKSHEET_NAME,
+                    balance_spreadsheet.PAYMENT_DESC_RANGE,
+                )
+            ]
+
+            expenses = expenses[
+                (~expenses.description.isin(payment_descriptions))
+            ].fillna("")
+
+            collected_transactions = [
                 Transaction(
                     **dict(zip(list(Transaction.model_fields), raw_transaction))
                 )
                 for raw_transaction in expenses.values.tolist()
-            ],
+            ]
+
+        account_data = AccountData(
+            identifier=self.identifier,
+            amount=self.amount,
+            transactions=collected_transactions,
         )
 
         (VigilantIOResources.OUTPUT_PATH / IOResources.OUTPUT_FILENAME).write_text(

--- a/vigilant/core/collector/scraper/banco_chile/values.py
+++ b/vigilant/core/collector/scraper/banco_chile/values.py
@@ -27,6 +27,7 @@ class Locators:
     PROMOTION_BANNER_CLASS: Final[str] = ".fondo"
     AMOUNT_TEXT_CLASS: Final[str] = ".monto-cuenta"
     DOWNLOAD_TOAST_CLASS: Final[str] = ".snackbar-text"
+    NO_TRANSACTIONS_CLASS: Final[str] = ".alert-error"
     LOGOUT_BTN_CLASS: Final[str] = ".button-logout"
 
     BANNER_CLOSE_BTN_XPATH: Final[str] = (

--- a/vigilant/core/update_spreadsheet.py
+++ b/vigilant/core/update_spreadsheet.py
@@ -1,10 +1,13 @@
 import json
 from pathlib import Path
+from typing import Final
 
 from vigilant import logger
 from vigilant.common.models import AccountData, AccountReport
 from vigilant.common.spreadsheet import SpreadSheet
 from vigilant.common.values import balance_spreadsheet, IOResources
+
+TRANSACTIONS_COUNT: Final[int] = 198
 
 
 def main() -> None:
@@ -39,6 +42,8 @@ def update_balance_spreadsheet(
         expenses (list[list[str]]): Expenses list
     """
     logger.info("Updating spreadsheet ...")
+
+    expenses.extend([["-", "", "", "", ""]] * (TRANSACTIONS_COUNT - len(expenses)))
 
     spreadsheet.write(
         balance_spreadsheet.EXPENSES_WORKSHEET_NAME,


### PR DESCRIPTION
Add support for handling scenarios where bank accounts have no transactions, improving robustness of the transaction collection process.

## Changes

- **Updated Banco Chile Scraper**: Added try/except block in `_get_credit_transactions()` to gracefully handle TimeoutError when no transactions are available
- **Enhanced `_save()` method**: Now checks if the transactions file exists before attempting to read it, allowing for empty transaction scenarios
- **Added transaction padding**: `update_balance_spreadsheet()` now pads the expenses list to a fixed count (198 transactions) to maintain consistent spreadsheet structure
- **Test coverage**: 
  - Added `test_get_credit_transactions_empty()` to verify timeout handling
  - Added `test_save_no_transactions()` to validate behavior with no transactions
  - Updated `test_save()` to use proper temporary paths and added `tmp_path_factory` fixture
  - Added new test fixture `bank_chile_no_transactions.json` for test data
- **New locator**: Added `NO_TRANSACTIONS_CLASS` constant for the "no transactions" error alert
- **Test infrastructure**: Added import for `TimeoutError` from `playwright.sync_api`

This resolves edge cases where accounts have no transactions, preventing crashes and ensuring data consistency in the spreadsheet.