### PR TITLE
Set format for expenses amount as CLP currency

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,64 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/poetry:2": {
+      "version": "2.0.18",
+      "resolved": "ghcr.io/devcontainers-extra/features/poetry@sha256:7b5f2c66d25d8b3cc5d601af6b81b720c77dd315f24d5e6f84b342cccc3c9228",
+      "integrity": "sha256:7b5f2c66d25d8b3cc5d601af6b81b720c77dd315f24d5e6f84b342cccc3c9228"
+    },
+    "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {
+      "version": "0.0.5",
+      "resolved": "ghcr.io/devcontainers-extra/features/zsh-plugins@sha256:4dcc8e97307345cff26c2b4dfd840c2947b8b5bb20f492a68bdb9fbe9ccb67ba",
+      "integrity": "sha256:4dcc8e97307345cff26c2b4dfd840c2947b8b5bb20f492a68bdb9fbe9ccb67ba"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.7",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4",
+      "integrity": "sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.9.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850",
+      "integrity": "sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.4.2",
+      "resolved": "ghcr.io/devcontainers/features/terraform@sha256:250d08e39c99d9e959e091e74527c22c04eeae728b424da99f002423c7902f82",
+      "integrity": "sha256:250d08e39c99d9e959e091e74527c22c04eeae728b424da99f002423c7902f82"
+    },
+    "ghcr.io/dhoeric/features/google-cloud-cli:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/dhoeric/features/google-cloud-cli@sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f",
+      "integrity": "sha256:fa5d894718825c5ad8009ac8f2c9f0cea3d1661eb108a9d465cba9f3fc48965f"
+    },
+    "ghcr.io/joshuanianji/devcontainer-features/gcloud-cli-persistence:1": {
+      "version": "1.0.3",
+      "resolved": "ghcr.io/joshuanianji/devcontainer-features/gcloud-cli-persistence@sha256:70fb7080d8647d0e3dd1b9b3a2a91b7f7f386744c3826cf108a51347657bae9f",
+      "integrity": "sha256:70fb7080d8647d0e3dd1b9b3a2a91b7f7f386744c3826cf108a51347657bae9f"
+    },
+    "ghcr.io/robbit-o/devex/zsh-p10k:0": {
+      "version": "0.1.1",
+      "resolved": "ghcr.io/robbit-o/devex/zsh-p10k@sha256:44129ca2db0c48fc3d1049272569484bcd0bb6152ca296a99ffa00ac1135d9ea",
+      "integrity": "sha256:44129ca2db0c48fc3d1049272569484bcd0bb6152ca296a99ffa00ac1135d9ea",
+      "dependsOn": [
+        "ghcr.io/devcontainers/features/common-utils:2",
+        "ghcr.io/devcontainers/features/git:1",
+        "ghcr.io/devcontainers-extra/features/zsh-plugins:0"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2": {"configureZshAsDefaultShell": true},
+        "ghcr.io/robbit-o/devex/zsh-p10k:0": {},
         "ghcr.io/devcontainers/features/python:1": {"version": "3.12"},
         "ghcr.io/devcontainers-extra/features/poetry:2": {},
         "ghcr.io/devcontainers/features/terraform:1": {},
@@ -12,8 +12,7 @@
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/dhoeric/features/google-cloud-cli:1": {},
-        "ghcr.io/joshuanianji/devcontainer-features/gcloud-cli-persistence:1": {},
-        "ghcr.io/gcornejov/devex/zsh-p10k:0": {}
+        "ghcr.io/joshuanianji/devcontainer-features/gcloud-cli-persistence:1": {}
     },
 
     "remoteEnv": {
@@ -56,11 +55,14 @@
                 "4ops.terraform"
             ],
             "settings": {
-                "python.defaultInterpreterPath": ".venv/bin/activate",
-                "python.testing.pytestEnabled": true,
-                "python.testing.pytestArgs": [
-                    "-s"
-                ]
+                "[python]": {
+                    "defaultInterpreterPath": ".venv/bin/python",
+                    "testing.pytestEnabled": true,
+                    "testing.pytestArgs": [
+                        "-s"
+                    ],
+                    "editor.defaultFormatter": "charliermarsh.ruff"
+                }
             }
         }
     },

--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ screenshots
 
 # Terraform
 .terraform*
+
+# GCloud Credentials
+credentials.json

--- a/tests/common/test_spreadsheet.py
+++ b/tests/common/test_spreadsheet.py
@@ -50,3 +50,29 @@ def test_write() -> None:
 
     _mock_spreadsheet.worksheet.assert_called_once_with(mock_title)
     mock_worksheet.update.assert_called_once_with(mock_data, mock_range)
+
+
+def test_format_currency() -> None:
+    mock_title = "Expenses"
+    mock_range = "A1:A10"
+
+    mock_worksheet = mock.MagicMock()
+    _mock_spreadsheet = mock.MagicMock()
+    _mock_spreadsheet.worksheet.return_value = mock_worksheet
+
+    spreadsheet.SpreadSheet(_mock_spreadsheet).format_currency(mock_title, mock_range)
+
+    _mock_spreadsheet.worksheet.assert_called_once_with(mock_title)
+    mock_worksheet.batch_format.assert_called_once_with(
+        [
+            {
+                "range": mock_range,
+                "format": {
+                    "numberFormat": {
+                        "type": "NUMBER",
+                        "pattern": '_ "$"* #,##0_ ;_ "$"* \-#,##0_ ;_ "$"* "-"_ ;_ @_ ',
+                    },
+                },
+            }
+        ]
+    )

--- a/tests/core/test_update_spreadsheet.py
+++ b/tests/core/test_update_spreadsheet.py
@@ -69,3 +69,8 @@ def test_update_balance_spreadsheet(MockSpreadSheet: mock.MagicMock) -> None:
     written_expenses = expenses_call[0][2]
 
     assert len(written_expenses) == update_spreadsheet.TRANSACTIONS_COUNT
+
+    mock_spreadsheet.format_currency.assert_called_once_with(
+        balance_spreadsheet.EXPENSES_WORKSHEET_NAME,
+        balance_spreadsheet.TRANSACTIONS_AMOUNT_RANGE,
+    )

--- a/vigilant/common/spreadsheet.py
+++ b/vigilant/common/spreadsheet.py
@@ -54,3 +54,26 @@ class SpreadSheet:
         worksheet: gspread.Worksheet = self._spreadsheet.worksheet(worksheet_title)
 
         worksheet.update(data, range)
+
+    def format_currency(self, worksheet_title: str, range: str) -> None:
+        """Formats a range of cells as CLP currency
+
+        Args:
+            worksheet_title (str): Title of the worksheet
+            range (str): Location from where to read the data
+        """
+        worksheet: gspread.Worksheet = self._spreadsheet.worksheet(worksheet_title)
+
+        worksheet.batch_format(
+            [
+                {
+                    "range": range,
+                    "format": {
+                        "numberFormat": {
+                            "type": "NUMBER",
+                            "pattern": '_ "$"* #,##0_ ;_ "$"* \-#,##0_ ;_ "$"* "-"_ ;_ @_ ',
+                        },
+                    },
+                }
+            ]
+        )

--- a/vigilant/common/values.py
+++ b/vigilant/common/values.py
@@ -36,6 +36,8 @@ class BalanceSpreadsheet(BaseSettings):
     AMOUNT_CELL: str = "J2"
     EXPENSES_CELL: str = "B3"
 
+    TRANSACTIONS_AMOUNT_RANGE: str = "F3:F200"
+
 
 settings = Settings()
 collector = Collector()

--- a/vigilant/core/update_spreadsheet.py
+++ b/vigilant/core/update_spreadsheet.py
@@ -56,6 +56,11 @@ def update_balance_spreadsheet(
         expenses,
     )
 
+    spreadsheet.format_currency(
+        balance_spreadsheet.EXPENSES_WORKSHEET_NAME,
+        balance_spreadsheet.TRANSACTIONS_AMOUNT_RANGE,
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Description
This PR adds currency formatting for expense amounts in the spreadsheet, displaying them as CLP (Chilean Peso) currency format.

## Changes
- **Feature Implementation:**
  - Added `format_currency()` method to `SpreadSheet` class to format cell ranges with CLP currency pattern
  - Added `TRANSACTIONS_AMOUNT_RANGE` constant to track the expense amount range (F3:F200)
  - Integrated currency formatting into the update spreadsheet workflow to automatically format expense amounts

- **Testing:**
  - Added `test_format_currency()` to verify the formatting method works correctly
  - Added assertion to verify currency formatting is called during spreadsheet updates

- **DevContainer Updates:**
  - Reorganized `.devcontainer.json` to `.devcontainer/devcontainer.json`
  - Added `devcontainer-lock.json` for feature version pinning
  - Updated Python interpreter path configuration
  - Added Ruff as default Python formatter
  - Updated zsh-p10k feature to robbit-o fork

- **Maintenance:**
  - Updated `.gitignore` to exclude `credentials.json`

## Impact
Expense amounts are now automatically formatted as CLP currency when spreadsheet updates occur, improving readability and consistency.