### PR TITLE
Add delay to Falabella login form click and refactor browser timeout configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,17 @@
+CHILE_USERNAME=username
+CHILE_PASSWORD=password
+
+CHILE_LOGIN_URL=https://chile.example.com/login
+CHILE_HOME_URL=https://chile.example.com/home
+CHILE_CREDIT_TRANSACTIONS_URL=https://chile.example.com/credit-transactions
+
+FALABELLA_USERNAME=username
+FALABELLA_PASSWORD=password
+
+FALABELLA_LOGIN_URL=https://falabella.example.com/login
+FALABELLA_HOME_URL=https://falabella.example.com/home
+
+GCLOUD_PROJECT=project-id
+BUCKET_NAME=screenshot-bucket
+
+STORAGE_LOCATION=local

--- a/README.md
+++ b/README.md
@@ -20,17 +20,10 @@
 
 ```shell
 gcloud auth application-default login \
-    --billing-project ${GCP_PROJECT_ID} \
+    --client-id-file credentials.json \
+    --billing-project ${GCLOUD_PROJECT} \
     --scopes https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive
 ```
-
-## Required environment variables
-
-- PORTAL_USERNAME
-- PORTAL_PASSWORD
-- PORTAL_LOGIN_URL
-- PORTAL_HOME_URL
-- CREDIT_TRANSACTIONS_URL
 
 ## Run application
 

--- a/tests/common/test_browser.py
+++ b/tests/common/test_browser.py
@@ -5,6 +5,7 @@ import pytest
 
 from vigilant.common import browser
 from vigilant.common.exceptions import DriverException
+from vigilant.common.values import settings
 
 
 @mock.patch("vigilant.common.browser.sync_playwright")
@@ -31,7 +32,7 @@ def test_session(
         "Chrome/123.0.0.0 Safari/537.36",
     )
     mock_browser.close.assert_called_once_with()
-    mock_page.set_default_timeout.assert_called_once_with(browser.WAIT_TIMEOUT)
+    mock_page.set_default_timeout.assert_called_once_with(settings.BROWSER_WAIT_TIMEOUT)
 
 
 @mock.patch("vigilant.common.browser.sync_playwright")

--- a/vigilant/common/browser.py
+++ b/vigilant/common/browser.py
@@ -1,7 +1,6 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Final
 
 from playwright.sync_api import (
     Browser,
@@ -18,8 +17,6 @@ from vigilant.common.values import (
     IOResources,
     StorageLocation,
 )
-
-WAIT_TIMEOUT: Final[float] = 20000.0
 
 storage = (
     GoogleCloudStorage()
@@ -42,7 +39,7 @@ def session() -> Generator[Page]:
             "Chrome/123.0.0.0 Safari/537.36",
         )
         page: Page = context.new_page()
-        page.set_default_timeout(WAIT_TIMEOUT)
+        page.set_default_timeout(settings.BROWSER_WAIT_TIMEOUT)
 
         try:
             yield page

--- a/vigilant/common/values.py
+++ b/vigilant/common/values.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     )
 
     LOG_LEVEL: str = "INFO"
+    BROWSER_WAIT_TIMEOUT: float = 30000.0
     STORAGE_LOCATION: str = "local"
     BUCKET_NAME: Optional[str] = None
 

--- a/vigilant/core/collector/scraper/banco_falabella/scraper.py
+++ b/vigilant/core/collector/scraper/banco_falabella/scraper.py
@@ -35,7 +35,7 @@ class BancoFalabellaScraper(Scraper):
 
         login_btn: Locator = self.page.locator(Locators.LOGIN_FORM_BTN_XPATH)
         login_btn.wait_for(state="visible")
-        login_btn.click()
+        login_btn.click(delay=1000.0)
 
         user_input: Locator = self.page.locator(Locators.USER_INPUT_XPATH).first
         user_input.wait_for(state="visible")


### PR DESCRIPTION
## Summary
This PR adds a delay to the Falabella login form button click to ensure the form is properly processed before proceeding, and refactors the browser wait timeout into a configurable setting.

## Changes
- **Banco Falabella Scraper**: Add 1-second delay to login button click to improve form submission reliability
- **Configuration**: Move hardcoded `WAIT_TIMEOUT` constant from `browser.py` to configurable `BROWSER_WAIT_TIMEOUT` setting in `values.py` (default: 30s)
- **Environment Variables**: Add `.env.template` file with example configuration for Chile and Falabella bank credentials and GCP settings
- **Documentation**: Update README with corrected gcloud authentication command and remove outdated environment variables section
- **Tests**: Update `test_browser.py` to use the new configurable `BROWSER_WAIT_TIMEOUT` setting