### PR TITLE
Isolate each scraper in its own browser session and harden Falabella scraping

### DIFF
--- a/tests/common/test_browser.py
+++ b/tests/common/test_browser.py
@@ -23,7 +23,15 @@ def test_session(
     with browser.session() as session:
         assert session == mock_page
 
-    mock_playwright_session.chromium.launch.assert_called_once_with(channel="chrome")
+    mock_playwright_session.chromium.launch.assert_called_once_with(
+        channel="chrome",
+        args=[
+            "--no-sandbox",
+            "--disable-setuid-sandbox",
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+        ],
+    )
     mock_browser.new_context.assert_called_once_with(
         accept_downloads=True,
         viewport={"width": 1920, "height": 1080},

--- a/vigilant/common/browser.py
+++ b/vigilant/common/browser.py
@@ -30,6 +30,12 @@ def session() -> Generator[Page]:
     with sync_playwright() as p:
         browser: Browser = p.chromium.launch(
             channel="chrome",
+            args=[
+                "--no-sandbox",
+                "--disable-setuid-sandbox",
+                "--disable-dev-shm-usage",
+                "--disable-gpu",
+            ],
         )
         context: BrowserContext = browser.new_context(
             accept_downloads=True,

--- a/vigilant/core/collector/main.py
+++ b/vigilant/core/collector/main.py
@@ -28,11 +28,11 @@ def get_enabled_scrapers() -> list[Type[Scraper]]:
 
 def collect() -> None:
     """Collect accounts data"""
-    with session() as page:
-        clear_resources()
+    clear_resources()
 
-        logger.info("Collecting transactions data ...")
-        for SPR in get_enabled_scrapers():
+    logger.info("Collecting transactions data ...")
+    for SPR in get_enabled_scrapers():
+        with session() as page:
             SPR(page).scrap()
 
 

--- a/vigilant/core/collector/scraper/banco_falabella/scraper.py
+++ b/vigilant/core/collector/scraper/banco_falabella/scraper.py
@@ -9,6 +9,7 @@ from vigilant.common.spreadsheet import SpreadSheet
 from vigilant.common.values import (
     balance_spreadsheet,
     IOResources as VigilantIOResources,
+    settings,
 )
 from vigilant.core.collector.scraper.banco_falabella.values import (
     secrets,
@@ -31,23 +32,26 @@ class BancoFalabellaScraper(Scraper):
         self.logger.info("Logging in ...")
 
         self.page.goto(secrets.LOGIN_URL)
-        self.page.wait_for_load_state()
+        self.page.wait_for_load_state("networkidle")
 
         login_btn: Locator = self.page.locator(Locators.LOGIN_FORM_BTN_XPATH)
-        login_btn.wait_for(state="visible")
-        login_btn.click(delay=1000.0)
+        login_btn.wait_for(state="visible", timeout=settings.BROWSER_WAIT_TIMEOUT)
+        login_btn.click(delay=500.0)
 
         user_input: Locator = self.page.locator(Locators.USER_INPUT_XPATH).first
-        user_input.wait_for(state="visible")
+        user_input.wait_for(state="visible", timeout=settings.BROWSER_WAIT_TIMEOUT)
         user_input.fill(secrets.USERNAME)
 
         password_input: Locator = self.page.locator(Locators.PASSWORD_INPUT_XPATH).first
-        password_input.wait_for(state="visible")
+        password_input.wait_for(state="visible", timeout=settings.BROWSER_WAIT_TIMEOUT)
         password_input.fill(secrets.PASSWORD)
 
-        self.page.locator(Locators.LOGIN_SUBMIT_BTN_ID).first.click()
+        submit_btn = self.page.locator(Locators.LOGIN_SUBMIT_BTN_ID).first
+        submit_btn.wait_for(state="visible", timeout=settings.BROWSER_WAIT_TIMEOUT)
+        submit_btn.click(delay=500.0)
 
-        self.page.wait_for_url(secrets.HOME_URL)
+        self.page.wait_for_url(secrets.HOME_URL, timeout=settings.BROWSER_WAIT_TIMEOUT)
+        self.page.wait_for_load_state("networkidle")
 
     def _get_credit_transactions(self) -> None:
         """Collect current transactions on credit card"""


### PR DESCRIPTION
## Summary 

- Changed `vigilant/core/collector/main.py` so each enabled scraper runs inside its own `session()` context instead of sharing a single browser page.
- Added robust Playwright launch args in `vigilant/common/browser.py` to improve Chrome compatibility in sandboxed/container environments.
- Updated `vigilant/core/collector/scraper/banco_falabella/scraper.py` with stronger wait logic:
  - wait for `networkidle` after navigation
  - use `settings.BROWSER_WAIT_TIMEOUT` for element visibility waits
  - add delayed submit click and explicit load state wait after login
- Extended `tests/common/test_browser.py` to verify the new browser launch args.