### PR TITLE
Improve CI/CD and build pipeline: secrets handling, action upgrades, and browser install order

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -73,27 +73,51 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    env:
-      TF_VAR_secrets: "${{ secrets.SECRETS_JSON }}"
     steps:
       - uses: actions/checkout@v6
-      -
-        name: Setup Terraform
+
+      - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ vars.TF_VERSION }}
           terraform_wrapper: false
-      -
-        name: GCP Auth
+
+      - name: GCP Auth
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.TF_SA }}
-      -
-        name: Terraform Init
+
+      - name: Load secrets into Env JSON
+        run: |
+          COMPACT_JSON=$(jq -c -n \
+            --arg chile_username "${{ secrets.CHILE_USERNAME }}" \
+            --arg chile_password "${{ secrets.CHILE_PASSWORD }}" \
+            --arg chile_login_url "${{ secrets.CHILE_LOGIN_URL }}" \
+            --arg chile_home_url "${{ secrets.CHILE_HOME_URL }}" \
+            --arg chile_credit_transactions_url "${{ secrets.CHILE_CREDIT_TRANSACTIONS_URL }}" \
+            --arg falabella_username "${{ secrets.FALABELLA_USERNAME }}" \
+            --arg falabella_password "${{ secrets.FALABELLA_PASSWORD }}" \
+            --arg falabella_login_url "${{ secrets.FALABELLA_LOGIN_URL }}" \
+            --arg falabella_home_url "${{ secrets.FALABELLA_HOME_URL }}" \
+            '{
+                CHILE_USERNAME: $chile_username,
+                CHILE_PASSWORD: $chile_password,
+                CHILE_LOGIN_URL: $chile_login_url,
+                CHILE_HOME_URL: $chile_home_url,
+                CHILE_CREDIT_TRANSACTIONS_URL: $chile_credit_transactions_url,
+                FALABELLA_USERNAME: $falabella_username,
+                FALABELLA_PASSWORD: $falabella_password,
+                FALABELLA_LOGIN_URL: $falabella_login_url,
+                FALABELLA_HOME_URL: $falabella_home_url
+            }')
+
+          echo "TF_VAR_secrets=${COMPACT_JSON}" >> $GITHUB_ENV
+
+      - name: Terraform Init
         working-directory: terraform
         run: terraform init
-      -
-        name: Terraform Apply
+
+      - name: Terraform Apply
         working-directory: terraform
         run: terraform apply --auto-approve -var service_image=${{ needs.docker.outputs.image }}

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -48,17 +48,17 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Build and push
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ${{ vars.DOCKERHUB_USERNAME }}/vigilant:${{ steps.image-tag.outputs.tag }}
@@ -76,16 +76,16 @@ jobs:
     env:
       TF_VAR_secrets: "${{ secrets.SECRETS_JSON }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       -
         name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ vars.TF_VERSION }}
           terraform_wrapper: false
       -
         name: GCP Auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.TF_SA }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -21,7 +21,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM thehale/python-poetry:2.1.3-py3.12-slim AS build-deps
+FROM thehale/python-poetry:2.4.1-py3.12-slim AS build-deps
 
 RUN poetry self add poetry-plugin-export
 
@@ -14,12 +14,13 @@ RUN apt update -y && apt upgrade -y
 # Create app folder
 RUN mkdir -p -m 777 /var/lib/vigilant
 
+# Install Chrome Browser and Driver
+RUN pip install --no-cache-dir --upgrade playwright && \
+    playwright install chrome --with-deps
+
 # Install dependencies
 COPY --from=build-deps /requirements.txt .
 RUN pip install --no-cache-dir --upgrade -r requirements.txt
-
-# Install Chrome Browser and Driver
-RUN playwright install chrome --with-deps
 
 # Copy app source code
 ADD vigilant /vigilant


### PR DESCRIPTION
## Summary

This PR consolidates recent pipeline improvements across GitHub Actions and the Docker build process.

## What changed

- Improved GitHub Actions secret handling in `.github/workflows/build-deploy.yml` by removing the direct `TF_VAR_secrets` environment injection and loading secrets into `GITHUB_ENV` using a compact JSON object.
- Updated GitHub Actions versions in `.github/workflows/build-deploy.yml` and `.github/workflows/test.yml` to newer supported releases:
  - `actions/checkout` to `v6`
  - `docker/login-action` to `v4`
  - `docker/setup-buildx-action` to `v4`
  - `docker/build-push-action` to `v7`
  - `hashicorp/setup-terraform` to `v4`
  - `google-github-actions/auth` to `v3`
  - `actions/setup-python` to `v6`
  - `actions/cache` to `v5`
- Adjusted the Dockerfile build order to install the Chrome browser and Playwright driver earlier, before dependency installation.

## Why

- Reduce risk from insecure or brittle secret propagation in the deployment workflow.
- Keep CI/CD dependencies current with upstream GitHub Actions releases.
- Ensure browser dependencies are available earlier in the build stage for a more reliable Docker image creation.

## Files changed

- `.github/workflows/build-deploy.yml`
- `.github/workflows/test.yml`
- `Dockerfile`